### PR TITLE
Fixed old imports and defines

### DIFF
--- a/src/imageclipper.cpp
+++ b/src/imageclipper.cpp
@@ -27,10 +27,10 @@
 #pragma warning(disable:4819) // Save the file in Unicode format to prevent data loss
 #endif
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
-#include "highgui.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
+#include <opencv/highgui.h>
 #include <stdio.h>
 #include <math.h>
 #include <iostream>

--- a/src/opencvx/cvbackground.h
+++ b/src/opencvx/cvbackground.h
@@ -24,9 +24,9 @@
 #ifndef CV_BACKGROUND_INCLUDED
 #define CV_BACKGROUND_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 
 CVAPI(void) cvBackground( const IplImage* _img, const IplImage* _ref, IplImage* _mask, int thresh = 100 );
 

--- a/src/opencvx/cvbackground.h
+++ b/src/opencvx/cvbackground.h
@@ -42,7 +42,7 @@ CVAPI(void) cvBackground( const IplImage* _img, const IplImage* _ref, IplImage* 
 CVAPI(void) cvBackground( const IplImage* _img, const IplImage* _ref, IplImage* _mask, int thresh )
 {
     CV_FUNCNAME( "cvBackground" ); // error handling
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( _img->width == _ref->width );
     CV_ASSERT( _img->width == _mask->width );
     CV_ASSERT( _img->height == _ref->height );
@@ -80,7 +80,7 @@ CVAPI(void) cvBackground( const IplImage* _img, const IplImage* _ref, IplImage* 
     cvReleaseImage( &img );
     cvReleaseImage( &ref );
     cvReleaseImage( &mask );
-    __END__;
+    __CV_END__;
 }
 
 /*

--- a/src/opencvx/cvcat.h
+++ b/src/opencvx/cvcat.h
@@ -61,7 +61,7 @@ CVAPI( void ) cvCat( const CvArr* src1arr, const CvArr* src2arr, CvArr* dstarr, 
     CvMat *src2 = (CvMat*)src2arr, src2stub;
     CvMat *dst  = (CvMat*)dstarr, dststub;
     CV_FUNCNAME( "cvCat" );
-    __BEGIN__;
+    __CV_BEGIN__;
     if( !CV_IS_MAT(src1) )
     {
         src1 = cvGetMat( src1, &src1stub, &coi );
@@ -117,7 +117,7 @@ CVAPI( void ) cvCat( const CvArr* src1arr, const CvArr* src2arr, CvArr* dstarr, 
         cvSetRows( src1, dst, 0, src1->rows );
         cvSetRows( src2, dst, src1->rows, src1->rows + src2->rows );
     }
-    __END__;
+    __CV_END__;
 }
 
 

--- a/src/opencvx/cvcat.h
+++ b/src/opencvx/cvcat.h
@@ -25,8 +25,8 @@
 #define CV_CAT_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 #include "cvsetrow.h"
 #include "cvsetcol.h"
 

--- a/src/opencvx/cvclosing.h
+++ b/src/opencvx/cvclosing.h
@@ -24,9 +24,9 @@
 #ifndef CV_CLOSING_INCLUDED
 #define CV_CLOSING_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 
 CVAPI(void) cvClosing( const CvArr* src, CvArr* dst, IplConvKernel* element = NULL, int iterations = 1 );
 

--- a/src/opencvx/cvcreateaffine.h
+++ b/src/opencvx/cvcreateaffine.h
@@ -24,9 +24,9 @@
 #ifndef CV_CREATEAFFINE_INCLUDED
 #define CV_CREATEAFFINE_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 #define _USE_MATH_DEFINES
 #include <math.h>
 

--- a/src/opencvx/cvcreateaffine.h
+++ b/src/opencvx/cvcreateaffine.h
@@ -59,7 +59,7 @@ CVAPI(void) cvCreateAffine( CvMat* affine, CvRect32f rect, CvPoint2D32f shear )
     double c, s;
     CvMat *R, *S, *A, hdr;
     CV_FUNCNAME( "cvCreateAffine" );
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( rect.width > 0 && rect.height > 0 );
     CV_ASSERT( affine->rows == 2 && affine->cols == 3 );
 
@@ -93,7 +93,7 @@ CVAPI(void) cvCreateAffine( CvMat* affine, CvRect32f rect, CvPoint2D32f shear )
 
     cvReleaseMat( &R );
     cvReleaseMat( &S );
-    __END__;
+    __CV_END__;
 }
 
 

--- a/src/opencvx/cvcreateaffineimage.h
+++ b/src/opencvx/cvcreateaffineimage.h
@@ -92,7 +92,7 @@ CVAPI(IplImage*) cvCreateAffineImage( const IplImage* src, const CvMat* affine,
     CvPoint pt[4];
     CvMat* invaffine;
     CV_FUNCNAME( "cvAffineImage" );
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( src->depth == IPL_DEPTH_8U );
     CV_ASSERT( affine->rows == 2 && affine->cols == 3 );
 
@@ -171,7 +171,7 @@ CVAPI(IplImage*) cvCreateAffineImage( const IplImage* src, const CvMat* affine,
         }
     }
     cvReleaseMat( &invaffine );
-    __END__;
+    __CV_END__;
     return dst;
 }
 

--- a/src/opencvx/cvcreateaffineimage.h
+++ b/src/opencvx/cvcreateaffineimage.h
@@ -24,9 +24,9 @@
 #ifndef CV_CREATEAFFINEIMAGE_INCLUDED
 #define CV_CREATEAFFINEIMAGE_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 #define _USE_MATH_DEFINES
 #include <math.h>
 #include <limits.h>

--- a/src/opencvx/cvcropimageroi.h
+++ b/src/opencvx/cvcropimageroi.h
@@ -61,7 +61,7 @@ CVAPI(void) cvCropImageROI( IplImage* img, IplImage* dst, CvRect32f rect32f, CvP
     CvRect rect = cvRectFromRect32f( rect32f );
     float angle = rect32f.angle;
     CV_FUNCNAME( "cvCropImageROI" );
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( rect.width > 0 && rect.height > 0 );
     CV_ASSERT( dst->width == rect.width );
     CV_ASSERT( dst->height == rect.height );
@@ -132,7 +132,7 @@ CVAPI(void) cvCropImageROI( IplImage* img, IplImage* dst, CvRect32f rect32f, CvP
         cvReleaseMat( &xy );
         cvReleaseMat( &xyp );
     }
-    __END__;
+    __CV_END__;
 }
 
 /**

--- a/src/opencvx/cvcropimageroi.h
+++ b/src/opencvx/cvcropimageroi.h
@@ -24,9 +24,9 @@
 #ifndef CV_CROPIMAGEROI_INCLUDED
 #define CV_CROPIMAGEROI_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 #define _USE_MATH_DEFINES
 #include <math.h>
 

--- a/src/opencvx/cvdrawrectangle.h
+++ b/src/opencvx/cvdrawrectangle.h
@@ -24,9 +24,9 @@
 #ifndef CV_DRAWRECTANGLE_INCLUDED
 #define CV_DRAWRECTANGLE_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 #define _USE_MATH_DEFINES
 #include <math.h>
 

--- a/src/opencvx/cvdrawrectangle.h
+++ b/src/opencvx/cvdrawrectangle.h
@@ -81,7 +81,7 @@ CVAPI(void) cvDrawRectangle( IplImage* img,
     CvRect rect = cvRectFromRect32f( rect32f );
     float angle = rect32f.angle;
     CV_FUNCNAME( "cvDrawRectangle" );
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( rect.width > 0 && rect.height > 0 );
 
     if( angle == 0 && shear.x == 0 && shear.y == 0 )
@@ -174,7 +174,7 @@ CVAPI(void) cvDrawRectangle( IplImage* img,
         cvReleaseMat( &xy );
         cvReleaseMat( &xyp );
     }
-    __END__;
+    __CV_END__;
 }
 
 /**

--- a/src/opencvx/cvgaussnorm.h
+++ b/src/opencvx/cvgaussnorm.h
@@ -65,7 +65,7 @@ void cvImgGaussNorm( const CvArr* img, CvArr* normed )
     CvMat *tmp_in;
     CvMat *sub_in;
     CV_FUNCNAME( "cvImgGaussNorm" );
-    __BEGIN__;
+    __CV_BEGIN__;
     if( !CV_IS_MAT(in) )
     {
         CV_CALL( in = cvGetMat( in, &instub, &coi ) );
@@ -117,7 +117,7 @@ void cvImgGaussNorm( const CvArr* img, CvArr* normed )
         cvReleaseMat( &tmp_in );
     }
     cvReleaseMat( &sub_in );
-    __END__;
+    __CV_END__;
 }
 
 

--- a/src/opencvx/cvgaussnorm.h
+++ b/src/opencvx/cvgaussnorm.h
@@ -25,8 +25,8 @@
 #define CV_GAUSSNORM_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 #define _USE_MATH_DEFINES
 #include <math.h>
 

--- a/src/opencvx/cvgausspdf.h
+++ b/src/opencvx/cvgausspdf.h
@@ -25,8 +25,8 @@
 #define CV_GAUSSPDF_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 #define _USE_MATH_DEFINES
 #include <math.h>
 

--- a/src/opencvx/cvgausspdf.h
+++ b/src/opencvx/cvgausspdf.h
@@ -71,7 +71,7 @@ void cvMatGaussPdf( const CvMat* samples, const CvMat* mean, const CvMat* cov, C
     int N = samples->cols;
     int type = samples->type;
     CV_FUNCNAME( "cvMatGaussPdf" ); // error handling
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( CV_IS_MAT(samples) );
     CV_ASSERT( CV_IS_MAT(mean) );
     CV_ASSERT( CV_IS_MAT(cov) );
@@ -114,7 +114,7 @@ void cvMatGaussPdf( const CvMat* samples, const CvMat* mean, const CvMat* cov, C
     cvReleaseMat( &subsample_T );
     cvReleaseMat( &value );
 
-    __END__;
+    __CV_END__;
 }
 
 /**

--- a/src/opencvx/cvgmmpdf.h
+++ b/src/opencvx/cvgmmpdf.h
@@ -17,8 +17,8 @@
 #define CV_GMMPDF_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 #include <stdio.h>
 #include <iostream>
 #define _USE_MATH_DEFINES

--- a/src/opencvx/cvgmmpdf.h
+++ b/src/opencvx/cvgmmpdf.h
@@ -71,7 +71,7 @@ void cvMatGmmPdf( const CvMat* samples, const CvMat* means, CvMat** covs, const 
     int K = means->cols;
     int type = samples->type;
     CV_FUNCNAME( "cvMatGmmPdf" ); // error handling
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( CV_IS_MAT(samples) );
     CV_ASSERT( CV_IS_MAT(means) );
     for( int k = 0; k < K; k++ )
@@ -110,7 +110,7 @@ void cvMatGmmPdf( const CvMat* samples, const CvMat* means, CvMat** covs, const 
     cvReleaseMat( &mean );
     cvReleaseMat( &_probs );
 
-    __END__;
+    __CV_END__;
 }
 
 /**

--- a/src/opencvx/cvinvaffine.h
+++ b/src/opencvx/cvinvaffine.h
@@ -41,7 +41,7 @@ CVAPI(void) cvInvAffine( const CvMat* affine, CvMat* invaffine );
 CVAPI(void) cvInvAffine( const CvMat* affine, CvMat* invaffine )
 {
     CV_FUNCNAME( "cvCreateAffine" );
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( affine->rows == 2 && affine->cols == 3 );
     CV_ASSERT( invaffine->rows == 2 && invaffine->cols == 3 );
     CV_ASSERT( affine->type == invaffine->type );
@@ -55,7 +55,7 @@ CVAPI(void) cvInvAffine( const CvMat* affine, CvMat* invaffine )
     cvSetRows( InvAffine, invaffine, 0, 2 );
     cvReleaseMat( &Affine );
     cvReleaseMat( &InvAffine );
-    __END__;
+    __CV_END__;
 }
 
 #endif

--- a/src/opencvx/cvinvaffine.h
+++ b/src/opencvx/cvinvaffine.h
@@ -24,9 +24,9 @@
 #ifndef CV_INVAFFINE_INCLUDED
 #define CV_INVAFFINE_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 
 #include "cvsetrow.h"
 

--- a/src/opencvx/cvipltocvdepth.h
+++ b/src/opencvx/cvipltocvdepth.h
@@ -25,7 +25,7 @@
 #define CV_IPLTOCVDEPTH_INCLUDED
 
 
-#include "cv.h"
+#include <opencv/cv.h>
 
 CVAPI(int) cvIplToCvDepth(int depth);
 

--- a/src/opencvx/cvipltocvtype.h
+++ b/src/opencvx/cvipltocvtype.h
@@ -25,7 +25,7 @@
 #define CV_IPLTOCVDEPTH_INCLUDED
 
 
-#include "cv.h"
+#include <opencv/cv.h>
 
 CV_INLINE int cvIplToCvType(int ipl_depth, int nChannels);
 

--- a/src/opencvx/cvlogsum.h
+++ b/src/opencvx/cvlogsum.h
@@ -24,9 +24,9 @@
 #ifndef CV_LOGSUM_INCLUDED
 #define CV_LOGSUM_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 
 #include <float.h>
 #include <math.h>

--- a/src/opencvx/cvlogsum.h
+++ b/src/opencvx/cvlogsum.h
@@ -51,7 +51,7 @@ CvScalar cvLogSum( const CvArr *arr )
     CvScalar sumval;
     CvScalar minval, maxval;
     CV_FUNCNAME( "cvLogSum" );
-    __BEGIN__;
+    __CV_BEGIN__;
 
     if( !CV_IS_IMAGE(img) )
     {
@@ -78,7 +78,7 @@ CvScalar cvLogSum( const CvArr *arr )
     }
     cvReleaseImage( &tmp );
     cvReleaseImage( &tmp2 );
-    __END__;
+    __CV_END__;
     return sumval;
 }
 

--- a/src/opencvx/cvmxmatconv.h
+++ b/src/opencvx/cvmxmatconv.h
@@ -61,7 +61,7 @@ CVAPI(mxArray*) cvmxArrayFromCvArr(const CvArr* arr)
     mxClassID classid; mxArray* mxarr = NULL;
     int row, col, ch;
 
-    __BEGIN__;
+    __CV_BEGIN__;
     if (!CV_IS_IMAGE(img)) {
         CV_CALL(img = cvGetImage(img, &imghdr));
     }
@@ -105,7 +105,7 @@ CVAPI(mxArray*) cvmxArrayFromCvArr(const CvArr* arr)
             }
         }
     }
-    __END__;
+    __CV_END__;
     return mxarr;
 }
 
@@ -129,7 +129,7 @@ CVAPI(IplImage*) cvmxArrayToIplImage(const mxArray* mxarr)
     mxClassID classid;
     int row, col, ch;
 
-    __BEGIN__;
+    __CV_BEGIN__;
     classid = mxGetClassID(mxarr);
     nDim = mxGetNumberOfDimensions(mxarr);
     dims = mxGetDimensions(mxarr);
@@ -168,7 +168,7 @@ CVAPI(IplImage*) cvmxArrayToIplImage(const mxArray* mxarr)
             }
         }
     }
-    __END__;
+    __CV_END__;
     return img;
 }
 

--- a/src/opencvx/cvmxmatconv.h
+++ b/src/opencvx/cvmxmatconv.h
@@ -30,7 +30,7 @@
 #define CVMX_MATCONV_INCLUDED
 
 
-#include "cv.h"
+#include <opencv/cv.h>
 #include "mat.h"
 #include "matrix.h"
 #include "cvmxtypeconv.h"

--- a/src/opencvx/cvmxtypeconv.h
+++ b/src/opencvx/cvmxtypeconv.h
@@ -30,7 +30,7 @@
 #define CVMX_TYPECONV_INCLUDED
 
 
-#include "cv.h"
+#include <opencv/cv.h>
 #include "mat.h"
 #include "matrix.h"
 #include "cvipltocvdepth.h"

--- a/src/opencvx/cvopening.h
+++ b/src/opencvx/cvopening.h
@@ -24,9 +24,9 @@
 #ifndef CV_OPENING_INCLUDED
 #define CV_OPENING_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 
 CVAPI( void ) cvOpening( const CvArr* src, CvArr* dst, IplConvKernel* element = NULL, int iterations = 1 );
 /**

--- a/src/opencvx/cvparticle.h
+++ b/src/opencvx/cvparticle.h
@@ -377,12 +377,12 @@ void cvParticleInit( CvParticle* p, const CvParticle* init )
 void cvParticleSetBound( CvParticle* p, const CvMat* bound )
 {
     CV_FUNCNAME( "cvParticleSetBound" );
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( p->num_states == bound->rows );
     CV_ASSERT( 3 == bound->cols );
     //cvCopy( bound, p->bound );
     cvConvert( bound, p->bound );
-    __END__;
+    __CV_END__;
 }
 
 /**
@@ -396,12 +396,12 @@ void cvParticleSetBound( CvParticle* p, const CvMat* bound )
 void cvParticleSetNoise( CvParticle* p, CvRNG rng, const CvMat* std )
 {
     CV_FUNCNAME( "cvParticleSetNoise" );
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( p->num_states == std->rows );
     p->rng = rng;
     //cvCopy( std, p->std );
     cvConvert( std, p->std );
-    __END__;
+    __CV_END__;
 }
 
 /**
@@ -414,12 +414,12 @@ void cvParticleSetNoise( CvParticle* p, CvRNG rng, const CvMat* std )
 void cvParticleSetDynamics( CvParticle* p, const CvMat* dynamics )
 {
     CV_FUNCNAME( "cvParticleSetDynamics" );
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( p->num_states == dynamics->rows );
     CV_ASSERT( p->num_states == dynamics->cols );
     //cvCopy( dynamics, p->dynamics );
     cvConvert( dynamics, p->dynamics );
-    __END__;
+    __CV_END__;
 }
 
 /**
@@ -432,7 +432,7 @@ void cvReleaseParticle( CvParticle** particle )
 {
     CvParticle *p = NULL;
     CV_FUNCNAME( "cvReleaseParticle" );
-    __BEGIN__;
+    __CV_BEGIN__;
     p = *particle;
     if( !p ) EXIT;
     
@@ -442,7 +442,7 @@ void cvReleaseParticle( CvParticle** particle )
     cvReleaseMat( &p->particles );
     cvReleaseMat( &p->probs );
     cvFree( &p );
-    __END__;
+    __CV_END__;
 }
 
 /**
@@ -459,7 +459,7 @@ CvParticle* cvCreateParticle( int num_states, int num_observes, int num_particle
 {
     CvParticle *p = NULL;
     CV_FUNCNAME( "cvCreateParticle" );
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( num_states > 0 );
     CV_ASSERT( num_observes > 0 );
     CV_ASSERT( num_particles > 0 );
@@ -483,7 +483,7 @@ CvParticle* cvCreateParticle( int num_states, int num_observes, int num_particle
 
     cvZero( p->bound );
 
-    __END__;
+    __CV_END__;
     return p;
 }
 

--- a/src/opencvx/cvparticle.h
+++ b/src/opencvx/cvparticle.h
@@ -32,9 +32,9 @@
 #ifndef CV_PARTICLE_INCLUDED
 #define CV_PARTICLE_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 
 #include <time.h>
 #include "cvsetrow.h"

--- a/src/opencvx/cvpcadiffs.h
+++ b/src/opencvx/cvpcadiffs.h
@@ -113,7 +113,7 @@ void cvMatPcaDiffs( const CvMat* samples, const CvMat* avg, const CvMat* eigenva
     CvMat *subsamples0, subsamples0hdr;
     CvScalar rho;
     CV_FUNCNAME( "cvMatPcaDiffs" );
-    __BEGIN__;
+    __CV_BEGIN__;
     CV_ASSERT( CV_IS_MAT(samples) );
     CV_ASSERT( CV_IS_MAT(avg) );
     CV_ASSERT( CV_IS_MAT(eigenvalues) );
@@ -210,7 +210,7 @@ void cvMatPcaDiffs( const CvMat* samples, const CvMat* avg, const CvMat* eigenva
     if( D == eigenvectors->rows ) {
         cvReleaseMat( &_eigenvectors );
     }
-    __END__;
+    __CV_END__;
 }
 
 /**

--- a/src/opencvx/cvpcadiffs.h
+++ b/src/opencvx/cvpcadiffs.h
@@ -12,8 +12,8 @@
 // program without meeting the above conditions.
 */
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 #include <stdio.h>
 #include <iostream>
 #define _USE_MATH_DEFINES

--- a/src/opencvx/cvpointnorm.h
+++ b/src/opencvx/cvpointnorm.h
@@ -24,9 +24,9 @@
 #ifndef CV_POINTNORM_INCLUDED
 #define CV_POINTNORM_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 #include <math.h>
 using namespace std;
 

--- a/src/opencvx/cvprintmat.h
+++ b/src/opencvx/cvprintmat.h
@@ -75,7 +75,7 @@ CV_INLINE void cvPrintImageProperty( const IplImage* img )
 CV_INLINE void cvPrintMat( const CvArr* arr )
 {
     CV_FUNCNAME( "cvPrintMat" );
-    __BEGIN__;
+    __CV_BEGIN__;
     int row, col, ch;
     int coi = 0;
     CvMat matstub, *mat = (CvMat*)arr;
@@ -110,7 +110,7 @@ CV_INLINE void cvPrintMat( const CvArr* arr )
         printf("\n");
     }
     fflush( stdout );
-    __END__;
+    __CV_END__;
 }
 
 

--- a/src/opencvx/cvprintmat.h
+++ b/src/opencvx/cvprintmat.h
@@ -25,8 +25,8 @@
 #define CV_PRINTMAT_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 #include <stdio.h>
 #include <iostream>
 

--- a/src/opencvx/cvputimageroi.h
+++ b/src/opencvx/cvputimageroi.h
@@ -24,9 +24,9 @@
 #ifndef CV_CROPIMAGEROI_INCLUDED
 #define CV_CROPIMAGEROI_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 #define _USE_MATH_DEFINES
 #include <math.h>
 

--- a/src/opencvx/cvputimageroi.h
+++ b/src/opencvx/cvputimageroi.h
@@ -72,7 +72,7 @@ CVAPI(void) cvPutImageROI( const IplImage* src,
     IplImage* _src = NULL;
     IplImage* _mask = NULL;
     CV_FUNCNAME( "cvPutImageROI" );
-    __BEGIN__;
+    __CV_BEGIN__;
     rect = cvRectFromRect32f( rect32f );
     angle = rect32f.angle;
 
@@ -167,7 +167,7 @@ CVAPI(void) cvPutImageROI( const IplImage* src,
         cvReleaseImage( &_mask );
     if( src != _src )
         cvReleaseImage( &_src );
-    __END__;
+    __CV_END__;
 }
 
 #endif

--- a/src/opencvx/cvrandgauss.h
+++ b/src/opencvx/cvrandgauss.h
@@ -25,8 +25,8 @@
 #define CV_RAND_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 
 double cvRandGauss( CvRNG* rng, double sigma );
 

--- a/src/opencvx/cvrect32f.h
+++ b/src/opencvx/cvrect32f.h
@@ -24,9 +24,9 @@
 #ifndef CV_RECT32F_INCLUDED
 #define CV_RECT32F_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 
 /******************* Structure Definitions ***************************/
 

--- a/src/opencvx/cvsandwichfill.h
+++ b/src/opencvx/cvsandwichfill.h
@@ -24,9 +24,9 @@
 #ifndef CV_CLOSING_INCLUDED
 #define CV_CLOSING_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 
 CVAPI(void) cvSandwichFill( const IplImage* src, IplImage* dst );
 

--- a/src/opencvx/cvsetcol.h
+++ b/src/opencvx/cvsetcol.h
@@ -59,7 +59,7 @@ CV_INLINE void cvSetCols( const CvArr* src, CvArr* dst,
     CvMat *refmat, refmathdr;
     int cols;
     CV_FUNCNAME( "cvSetCols" );
-    __BEGIN__;
+    __CV_BEGIN__;
     if( !CV_IS_MAT(dstmat) )
     {
         CV_CALL( dstmat = cvGetMat( dstmat, &dstmatstub, &coi ) );
@@ -82,14 +82,14 @@ CV_INLINE void cvSetCols( const CvArr* src, CvArr* dst,
         refmat = cvGetCols( srcmat, &refmathdr, start_col, end_col );
         cvCopy( refmat, dstmat );
     }
-    __END__;
+    __CV_END__;
 }
 
 /*
 CVAPI( void ) cvSetCols( const CvArr* subarr, CvArr* arr, int start_col, int end_col )
 {
 CV_FUNCNAME( "cvSetCols" );
-    __BEGIN__;
+    __CV_BEGIN__;
     int col, row, elem;
     int coi = 0;
     CvMat* submat = (CvMat*)subarr, submatstub;
@@ -123,7 +123,7 @@ CV_FUNCNAME( "cvSetCols" );
             }
         }
     }
-    __END__;
+    __CV_END__;
 }
 */
 

--- a/src/opencvx/cvsetcol.h
+++ b/src/opencvx/cvsetcol.h
@@ -25,8 +25,8 @@
 #define CV_SETCOL_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 
 CV_INLINE void cvSetCols( const CvArr* src, CvArr* dst,
                           int start_col, int end_col );

--- a/src/opencvx/cvsetrow.h
+++ b/src/opencvx/cvsetrow.h
@@ -25,8 +25,8 @@
 #define CV_SETROW_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 
 CV_INLINE void cvSetRows( const CvArr* src, CvArr* dst,
                          int start_row, int end_row, int delta_row = 1 );

--- a/src/opencvx/cvsetrow.h
+++ b/src/opencvx/cvsetrow.h
@@ -62,7 +62,7 @@ CV_INLINE void cvSetRows( const CvArr* src, CvArr* dst,
     CvMat *refmat, refmathdr;
     int rows;
     CV_FUNCNAME( "cvSetRows" );
-    __BEGIN__;
+    __CV_BEGIN__;
     if( !CV_IS_MAT(dstmat) )
     {
         CV_CALL( dstmat = cvGetMat( dstmat, &dstmatstub, &coi ) );
@@ -85,13 +85,13 @@ CV_INLINE void cvSetRows( const CvArr* src, CvArr* dst,
         refmat = cvGetRows( srcmat, &refmathdr, start_row, end_row, delta_row );
         cvCopy( refmat, dstmat );
     }
-    __END__;
+    __CV_END__;
 }
 /*
 CVAPI( void ) cvSetRows( const CvArr* subarr, CvArr* arr, int start_row, int end_row )
 {
     CV_FUNCNAME( "cvSetRows" );
-    __BEGIN__;
+    __CV_BEGIN__;
     int row, col, elem;
     int coi = 0;
     CvMat* submat = (CvMat*)subarr, submatstub;
@@ -131,7 +131,7 @@ CVAPI( void ) cvSetRows( const CvArr* subarr, CvArr* arr, int start_row, int end
             }
         }
     }
-    __END__;
+    __CV_END__;
 }
 */
 

--- a/src/opencvx/cvskincolorcbcr.h
+++ b/src/opencvx/cvskincolorcbcr.h
@@ -40,7 +40,7 @@ void cvSkinColorCrCb( const IplImage* _img, IplImage* mask, CvArr* distarr = NUL
 void cvSkinColorCrCb( const IplImage* _img, IplImage* mask, CvArr* distarr )
 {
     CV_FUNCNAME( "cvSkinColorCbCr" );
-    __BEGIN__;
+    __CV_BEGIN__;
     int width  = _img->width;
     int height = _img->height;
     CvMat* dist = (CvMat*)distarr, diststub;
@@ -132,7 +132,7 @@ void cvSkinColorCrCb( const IplImage* _img, IplImage* mask, CvArr* distarr )
             }
         }
     }
-    __END__;
+    __CV_END__;
 }
 
 

--- a/src/opencvx/cvskincolorcbcr.h
+++ b/src/opencvx/cvskincolorcbcr.h
@@ -15,8 +15,8 @@
 #define CV_SKINCOLOR_CBCR_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 #define _USE_MATH_DEFINES
 #include <math.h>
 

--- a/src/opencvx/cvskincolorgauss.h
+++ b/src/opencvx/cvskincolorgauss.h
@@ -15,8 +15,8 @@
 #define CV_SKINCOLOR_GAUSS_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 #define _USE_MATH_DEFINES
 #include <math.h>
 

--- a/src/opencvx/cvskincolorgmm.h
+++ b/src/opencvx/cvskincolorgmm.h
@@ -15,8 +15,8 @@
 #define CV_SKINCOLOR_GMM_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 #define _USE_MATH_DEFINES
 #include <math.h>
 

--- a/src/opencvx/cvskincolorgmm.h
+++ b/src/opencvx/cvskincolorgmm.h
@@ -55,7 +55,7 @@ void cvSkinColorGmm( const IplImage* _img, IplImage* mask, double threshold = 1.
 void cvSkinColorGmm( const IplImage* _img, IplImage* mask, double threshold, IplImage* probs )
 {
     CV_FUNCNAME( "cvSkinColorGmm" );
-    __BEGIN__;
+    __CV_BEGIN__;
     const int N = _img->height * _img->width;
     const int D = 3;
     const int K = 16;
@@ -163,7 +163,7 @@ void cvSkinColorGmm( const IplImage* _img, IplImage* mask, double threshold, Ipl
     cvReleaseMat( &Mask );
     cvReleaseImage( &img );
 
-    __END__;
+    __CV_END__;
 }
 
 

--- a/src/opencvx/cvskincolorpeer.h
+++ b/src/opencvx/cvskincolorpeer.h
@@ -15,8 +15,8 @@
 #define CV_SKINCOLOR_PEER_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 using namespace std;
 
 void cvSkinColorPeer( const IplImage* img, IplImage* mask );

--- a/src/opencvx/cvwaitfps.h
+++ b/src/opencvx/cvwaitfps.h
@@ -24,9 +24,9 @@
 #ifndef CV_WAITFPS_INCLUDED
 #define CV_WAITFPS_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 
 #include <time.h>
 

--- a/src/opencvx/cvxmat.h
+++ b/src/opencvx/cvxmat.h
@@ -24,9 +24,9 @@
 #ifndef CV_MATEXT_INCLUDED
 #define CV_MATEXT_INCLUDED
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cxcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cxcore.h>
 
 #include "cvmatelemcn.h"
 #include "cvprintmat.h"

--- a/src/opencvx/cvxmorphological.h
+++ b/src/opencvx/cvxmorphological.h
@@ -15,8 +15,8 @@
 #define CV_MORPHOLOGICAL_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 
 #include "cvopening.h"
 #include "cvclosing.h"

--- a/src/opencvx/cvxrectangle.h
+++ b/src/opencvx/cvxrectangle.h
@@ -25,9 +25,9 @@
 #define CV_RECTANGLE_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
-#include "cvcore.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
+#include <opencv/cvcore.h>
 #include "highgui.h"
 #include <stdio.h>
 #define _USE_MATH_DEFINES

--- a/src/opencvx/cvxskincolor.h
+++ b/src/opencvx/cvxskincolor.h
@@ -17,8 +17,8 @@
 #define CV_SKINCOLOR_INCLUDED
 
 
-#include "cv.h"
-#include "cvaux.h"
+#include <opencv/cv.h>
+#include <opencv/cvaux.h>
 #include <stdio.h>
 #include <iostream>
 #define _USE_MATH_DEFINES


### PR DESCRIPTION
Was having trouble building imageclipper, even when supplying a path to my OpenCV build. Changed all imports of OpenCV-related stuff to the standard ones. Also fixed the __BEGIN__ and __END__ defines.