### PR TITLE
Fix compilation error when OpenCV in non-standard location.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(OpenCV REQUIRED)
 
 add_executable(imageclipper src/imageclipper.cpp)
 
-include_directories(${Boost_INCLUDE_DIR} src)
+include_directories(${Boost_INCLUDE_DIR} ${OpenCV_INCLUDE_DIRS} src)
 link_directories(${Boost_LIBRARY_DIR})
 target_link_libraries(imageclipper ${OpenCV_LIBS} ${Boost_LIBRARIES})
 


### PR DESCRIPTION
I got OpenCV from homebrew, which puts the library under /usr/local/Cellar/opencv3/, without creating symlinks in standard locations.
`cmake -DOpenCV_DIR=/usr/local/Cellar/opencv3/3.0.0/share/OpenCV/ ..` run fine, but the build used to fail with `opencv/cv.h' file not found`.