### PR TITLE
add c++ version flags for compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ if (WITH_TBB)
 	target_link_libraries(imageclipper ${TBB_LIBRARIES})
 endif()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
 message("OpenCV Libs: ${OpenCV_LIBS}")
 message("Boost libs: ${Boost_LIBRARIES}")
 message("Boost link dir: ${Boost_LIBRARY_DIR}")


### PR DESCRIPTION
I was having trouble compiling on Ubuntu 16.04 with all the packages reinstalled. This flag solved this error
 `imageclipper/src/imageclipper.cpp:83:3: error: ‘nullptr’ was not declared in this scope
   nullptr,
   ^
`