### PR TITLE
Fixes to run with OpenCV 3.14

### DIFF
--- a/src/cvdrawwatershed.h
+++ b/src/cvdrawwatershed.h
@@ -29,6 +29,8 @@
 #include <stdio.h>
 #include <string>
 
+#include <opencv2/imgproc.hpp>
+
 // marker's shape is like circle
 // just for imageclipper.cpp for now
 CvRect cvDrawWatershed(IplImage* img, const CvRect circle)
@@ -68,7 +70,7 @@ inline CvRect cvShowImageAndWatershed(const char* w_name, const IplImage* img, c
 {
 	IplImage* clone = cvCloneImage(img);
 	CvRect rect = cvDrawWatershed(clone, circle);
-	cvRectangle(clone, cvPoint(rect.x, rect.y), cvPoint(rect.x + rect.width, rect.y + rect.height), CV_RGB(255, 255, 0), 1);
+	cvRectangle(clone, cvPoint(rect.x, rect.y), cvPoint(rect.x + rect.width, rect.y + rect.height), cvScalar(0, 255, 255), 1);
 	cvShowImage(w_name, clone);
 	cvReleaseImage(&clone);
 	return rect;

--- a/src/opencvx/cvdrawrectangle.h
+++ b/src/opencvx/cvdrawrectangle.h
@@ -36,14 +36,14 @@
 CVAPI(void) cvDrawRectangle(IplImage* img,
 	CvRect32f rect32f = cvRect32f(0, 0, 1, 1, 0),
 	CvPoint2D32f shear = cvPoint2D32f(0, 0),
-	CvScalar color = CV_RGB(255, 255, 255),
+	CvScalar color = cvScalar(255, 255, 255),
 	int thickness = 1,
 	int line_type = 8,
 	int shift = 0);
 CVAPI(void) cvShowImageAndRectangle(const char* w_name, const IplImage* img,
 	CvRect32f rect32f = cvRect32f(0, 0, 1, 1, 0),
 	CvPoint2D32f shear = cvPoint2D32f(0, 0),
-	CvScalar color = CV_RGB(255, 255, 0),
+	CvScalar color = cvScalar(0, 255, 255),
 	int thickness = 1, int line_type = 8,
 	int shift = 0);
 


### PR DESCRIPTION
This also fixes
https://github.com/JoakimSoderberg/imageclipper/issues/22, which I
assume is related to the newer OpenCV version as well.